### PR TITLE
Fix the widget and report.

### DIFF
--- a/lib/client-report.less
+++ b/lib/client-report.less
@@ -6,7 +6,7 @@
 
   background: rgba(255, 255, 255, 1);
   color: black;
-  position: absolute;
+  position: fixed;
   top: 20px;
   left: 20px;
   right: 20px;

--- a/lib/status-widget.less
+++ b/lib/status-widget.less
@@ -1,5 +1,5 @@
 #velocity-status-widget {
-    position: absolute;
+    position: fixed;
     top: 10px;
     right: 10px;
     width: 20px;


### PR DESCRIPTION
It's annoying to scroll to the top of the page to see the status of the tests. This is part of the solution. The notification icon/circle should also be draggable in case there's something in that position.
