### PR TITLE
Client report moved to inside an iframe

### DIFF
--- a/lib/client-report.html
+++ b/lib/client-report.html
@@ -4,39 +4,7 @@
 
 <template name="velocity">
   <div id="velocityOverlay" style="display: {{overlayIsVisible}};">
-    <div class="container">
-      {{#if resetting}}
-        {{> velocityResetNotification}}
-      {{/if}}
-
-      <div class="row control-row">
-        <div class="col-md-3 control-pane">
-          {{> velocityControlPanel}}
-        </div>
-        <div class="col-md-9 content-pane">
-          {{#each frameworks}}
-            {{> velocityReports}}
-          {{/each}}
-
-          {{#if active 'showLogs'}}
-            <h3>Logs</h3>
-            {{> velocityLogs}}
-          {{/if}}
-
-          {{#if active 'showFiles'}}
-            <h3>Test Files</h3>
-            {{> velocityTestFiles}}
-          {{/if}}
-
-          {{#if mochaPresent}}
-          <div class="iframe {{#if active 'showMochaIframe'}}visible{{/if}}">
-            <h3>Mocha iFrame</h3>
-            {{> mochaweb}}
-          </div>
-          {{/if}}
-        </div>
-      </div>
-    </div>
+    <iframe></iframe>
   </div>
 
   <!-- The status widget is the display-toggle circle in the upper-right -->
@@ -44,6 +12,42 @@
      class="{{statusWidgetClass}} display-toggle"
      data-target="velocityOverlay"></a>
 
+</template>
+
+<template name="velocityInsideOverlay">
+  <div class="container">
+    {{#if resetting}}
+      {{> velocityResetNotification}}
+    {{/if}}
+
+    <div class="row control-row">
+      <div class="col-md-3 control-pane">
+        {{> velocityControlPanel}}
+      </div>
+      <div class="col-md-9 content-pane">
+        {{#each frameworks}}
+          {{> velocityReports}}
+        {{/each}}
+
+        {{#if active 'showLogs'}}
+          <h3>Logs</h3>
+          {{> velocityLogs}}
+        {{/if}}
+
+        {{#if active 'showFiles'}}
+          <h3>Test Files</h3>
+          {{> velocityTestFiles}}
+        {{/if}}
+
+        {{#if mochaPresent}}
+        <div class="iframe {{#if active 'showMochaIframe'}}visible{{/if}}">
+          <h3>Mocha iFrame</h3>
+          {{> mochaweb}}
+        </div>
+        {{/if}}
+      </div>
+    </div>
+  </div>
 </template>
 
 <template name="velocityControlPanel">

--- a/lib/client-report.js
+++ b/lib/client-report.js
@@ -28,7 +28,7 @@ function nightwatchPresent() {
 
 
 
-Template.velocity.helpers({
+Template.velocityInsideOverlay.helpers({
   resetting: function () {
     return Session.get('resettingVelocity')
   },
@@ -208,13 +208,22 @@ Template.velocityLogs.isVisible = function () {
   return amplify.store('velocityLogsIsVisible') ? 'block' : 'none';
 };
 
+Template.velocity.rendered = function() {
+  var frame = this.find('iframe'),
+      frameBody = frame.contentWindow.document.body;
+  Blaze.render(Template.velocityInsideOverlay, frameBody);
+};
+
 Template.velocity.events({
   'click .display-toggle': function (e) {
     var targetId = $(e.target).data('target'),
         $target = $('#' + targetId);
     $target.toggle();
     amplify.store(targetId + 'IsVisible', $target.is(':visible'));
-  },
+  }
+});
+
+Template.velocityInsideOverlay.events({
   'change input:checkbox': function (e) {
     var targetId = e.target.id
     reamplify.store(e.target.id, e.target.checked);

--- a/lib/client-report.less
+++ b/lib/client-report.less
@@ -6,15 +6,22 @@
   @import "bootstrap/bootstrap.imports.less";
 
   color: black;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   right: 0;
+  bottom: 0;
 
   font-family: 'helvetica neue', helvetica, sans-serif;
   font-size: 16px;
   text-align:left;
   z-index: 2147483646;
+
+  >iframe {
+    border: 0;
+    width: 100%;
+    height: 100%;
+  }
 
   .container {
     height: 100vh;


### PR DESCRIPTION
In response to https://github.com/meteor-velocity/html-reporter/issues/27 (Overlay is overly sensitive to body page styles)

I have moved the client report into an iframe. This is necessary to fully isolate the CSS.

So far I haven't done anything to make the styles work inside the iframe yet. 
Maybe easiest to read CSS contents into a `<style>` tag using `Asset.getText`? 
Otherwise, I don't know how to link to the asset without [this grep hack](https://github.com/numtel/phantomjs-persistent-server/blob/d68da707f4de54a529120d457eaba195555b4e60/assetKey.js) I employed in a package of mine.
Both of these paths bypass the less preprocessor though...

Discussion?
![screenshot from 2014-10-22 02 52 32](https://cloud.githubusercontent.com/assets/518698/4734236/62856948-59d1-11e4-8efd-bfc7dbf2eeb3.png)
