### PR TITLE
Only show widget if not running in mirror (#54)

### DIFF
--- a/lib/client-report.html
+++ b/lib/client-report.html
@@ -3,6 +3,7 @@
 </body>
 
 <template name="velocity">
+  {{#if notInMirror}}
   <div id="velocityOverlay" class="{{#if overlayIsVisible}}visible{{/if}} {{statusWidgetClass}}">
     <button class="velocity-btn-close display-toggle" data-target="velocityOverlay"></button>
 
@@ -48,6 +49,7 @@
        data-target="velocityOverlay" title="Show test results">
     <i class="velocity-icon-status"></i>
   </div>
+  {{/if}}
 </template>
 
 <template name="velocitySummary">

--- a/lib/client-report.js
+++ b/lib/client-report.js
@@ -30,6 +30,21 @@ function nightwatchPresent() {
   return !! VelocityAggregateReports.findOne({'name': 'nightwatch'});
 }
 
+Template.velocity.created = function () {
+  // Only show widget when we know we are NOT running in a Velocity Mirror
+  Session.setDefault('velocity.isMirror', true);
+ 
+  // Determine if session is running in a Velocity mirror or not
+  Meteor.call('velocity/isMirror', function (err, res) {
+    if (err) {
+      // Log error. HTML Reporter will not be shown
+      console.log(err);
+    } else {
+      Session.set('velocity.isMirror', res);
+    } 
+  })
+};
+
 Template.velocity.helpers({
   statusWidgetClass: function () {
     var aggregateResult = VelocityAggregateReports.findOne({name: 'aggregateResult'});
@@ -58,6 +73,10 @@ Template.velocity.helpers({
   },
   overlayIsVisible: function () {
     return amplify.store('velocityOverlayIsVisible')
+  },
+  notInMirror: function () {
+    // This causes the html reporter to remain hidden if running in a Velocity mirror
+    return Session.equals('velocity.isMirror', false);
   },
   mochaPresent: mochaPresent,
   nightwatchPresent: nightwatchPresent

--- a/lib/client-report.js
+++ b/lib/client-report.js
@@ -38,7 +38,7 @@ Template.velocity.created = function () {
   Meteor.call('velocity/isMirror', function (err, res) {
     if (err) {
       // Log error. HTML Reporter will not be shown
-      console.log(err);
+      console.error(err);
     } else {
       Session.set('velocity.isMirror', res);
     } 

--- a/lib/client-report.less
+++ b/lib/client-report.less
@@ -456,3 +456,7 @@
     max-width: 500px;
   }
 }
+
+#velocity-status-widget {
+  transition: right 0.25s ease-in-out;
+}


### PR DESCRIPTION
On template creation, the ‘velocity’ template contents are no longer
added to the DOM.  The contents are only added if it is subsequently
determined that the browser session is NOT running in a velocity
mirror.  Users may see a very short delay before the status widget
appears, depending on how long it takes for the call to the
`velocity/isMirror’ takes to return a value.

This logic ensures that browser sessions running in a mirror will NEVER
display the status widget.  This is very helpful for automated
end-to-end UI tests, because it ensures the widget can never obscure
other elements underneath it.