### PR TITLE
shadowStyles CSS Isolation library installed

### DIFF
--- a/dist/mutationObserver.polyfill.js
+++ b/dist/mutationObserver.polyfill.js
@@ -1,0 +1,322 @@
+/* http://www.x-tags.org/download?byob=,WeakMap,MutationObserver */ 
+if (typeof WeakMap === "undefined") {
+    (function() {
+        var defineProperty = Object.defineProperty;
+        var counter = Date.now() % 1e9;
+        var WeakMap = function() {
+            this.name = "__st" + (Math.random() * 1e9 >>> 0) + (counter++ + "__");
+        };
+        WeakMap.prototype = {
+            set: function(key, value) {
+                var entry = key[this.name];
+                if (entry && entry[0] === key) entry[1] = value; else defineProperty(key, this.name, {
+                    value: [ key, value ],
+                    writable: true
+                });
+            },
+            get: function(key) {
+                var entry;
+                return (entry = key[this.name]) && entry[0] === key ? entry[1] : undefined;
+            },
+            "delete": function(key) {
+                this.set(key, undefined);
+            }
+        };
+        window.WeakMap = WeakMap;
+    })();
+}
+(function(global) {
+    var registrationsTable = new WeakMap();
+    var setImmediate = window.msSetImmediate;
+    if (!setImmediate) {
+        var setImmediateQueue = [];
+        var sentinel = String(Math.random());
+        window.addEventListener("message", function(e) {
+            if (e.data === sentinel) {
+                var queue = setImmediateQueue;
+                setImmediateQueue = [];
+                queue.forEach(function(func) {
+                    func();
+                });
+            }
+        });
+        setImmediate = function(func) {
+            setImmediateQueue.push(func);
+            window.postMessage(sentinel, "*");
+        };
+    }
+    var isScheduled = false;
+    var scheduledObservers = [];
+    function scheduleCallback(observer) {
+        scheduledObservers.push(observer);
+        if (!isScheduled) {
+            isScheduled = true;
+            setImmediate(dispatchCallbacks);
+        }
+    }
+    function wrapIfNeeded(node) {
+        return window.ShadowDOMPolyfill && window.ShadowDOMPolyfill.wrapIfNeeded(node) || node;
+    }
+    function dispatchCallbacks() {
+        isScheduled = false;
+        var observers = scheduledObservers;
+        scheduledObservers = [];
+        observers.sort(function(o1, o2) {
+            return o1.uid_ - o2.uid_;
+        });
+        var anyNonEmpty = false;
+        observers.forEach(function(observer) {
+            var queue = observer.takeRecords();
+            removeTransientObserversFor(observer);
+            if (queue.length) {
+                observer.callback_(queue, observer);
+                anyNonEmpty = true;
+            }
+        });
+        if (anyNonEmpty) dispatchCallbacks();
+    }
+    function removeTransientObserversFor(observer) {
+        observer.nodes_.forEach(function(node) {
+            var registrations = registrationsTable.get(node);
+            if (!registrations) return;
+            registrations.forEach(function(registration) {
+                if (registration.observer === observer) registration.removeTransientObservers();
+            });
+        });
+    }
+    function forEachAncestorAndObserverEnqueueRecord(target, callback) {
+        for (var node = target; node; node = node.parentNode) {
+            var registrations = registrationsTable.get(node);
+            if (registrations) {
+                for (var j = 0; j < registrations.length; j++) {
+                    var registration = registrations[j];
+                    var options = registration.options;
+                    if (node !== target && !options.subtree) continue;
+                    var record = callback(options);
+                    if (record) registration.enqueue(record);
+                }
+            }
+        }
+    }
+    var uidCounter = 0;
+    function JsMutationObserver(callback) {
+        this.callback_ = callback;
+        this.nodes_ = [];
+        this.records_ = [];
+        this.uid_ = ++uidCounter;
+    }
+    JsMutationObserver.prototype = {
+        observe: function(target, options) {
+            target = wrapIfNeeded(target);
+            if (!options.childList && !options.attributes && !options.characterData || options.attributeOldValue && !options.attributes || options.attributeFilter && options.attributeFilter.length && !options.attributes || options.characterDataOldValue && !options.characterData) {
+                throw new SyntaxError();
+            }
+            var registrations = registrationsTable.get(target);
+            if (!registrations) registrationsTable.set(target, registrations = []);
+            var registration;
+            for (var i = 0; i < registrations.length; i++) {
+                if (registrations[i].observer === this) {
+                    registration = registrations[i];
+                    registration.removeListeners();
+                    registration.options = options;
+                    break;
+                }
+            }
+            if (!registration) {
+                registration = new Registration(this, target, options);
+                registrations.push(registration);
+                this.nodes_.push(target);
+            }
+            registration.addListeners();
+        },
+        disconnect: function() {
+            this.nodes_.forEach(function(node) {
+                var registrations = registrationsTable.get(node);
+                for (var i = 0; i < registrations.length; i++) {
+                    var registration = registrations[i];
+                    if (registration.observer === this) {
+                        registration.removeListeners();
+                        registrations.splice(i, 1);
+                        break;
+                    }
+                }
+            }, this);
+            this.records_ = [];
+        },
+        takeRecords: function() {
+            var copyOfRecords = this.records_;
+            this.records_ = [];
+            return copyOfRecords;
+        }
+    };
+    function MutationRecord(type, target) {
+        this.type = type;
+        this.target = target;
+        this.addedNodes = [];
+        this.removedNodes = [];
+        this.previousSibling = null;
+        this.nextSibling = null;
+        this.attributeName = null;
+        this.attributeNamespace = null;
+        this.oldValue = null;
+    }
+    function copyMutationRecord(original) {
+        var record = new MutationRecord(original.type, original.target);
+        record.addedNodes = original.addedNodes.slice();
+        record.removedNodes = original.removedNodes.slice();
+        record.previousSibling = original.previousSibling;
+        record.nextSibling = original.nextSibling;
+        record.attributeName = original.attributeName;
+        record.attributeNamespace = original.attributeNamespace;
+        record.oldValue = original.oldValue;
+        return record;
+    }
+    var currentRecord, recordWithOldValue;
+    function getRecord(type, target) {
+        return currentRecord = new MutationRecord(type, target);
+    }
+    function getRecordWithOldValue(oldValue) {
+        if (recordWithOldValue) return recordWithOldValue;
+        recordWithOldValue = copyMutationRecord(currentRecord);
+        recordWithOldValue.oldValue = oldValue;
+        return recordWithOldValue;
+    }
+    function clearRecords() {
+        currentRecord = recordWithOldValue = undefined;
+    }
+    function recordRepresentsCurrentMutation(record) {
+        return record === recordWithOldValue || record === currentRecord;
+    }
+    function selectRecord(lastRecord, newRecord) {
+        if (lastRecord === newRecord) return lastRecord;
+        if (recordWithOldValue && recordRepresentsCurrentMutation(lastRecord)) return recordWithOldValue;
+        return null;
+    }
+    function Registration(observer, target, options) {
+        this.observer = observer;
+        this.target = target;
+        this.options = options;
+        this.transientObservedNodes = [];
+    }
+    Registration.prototype = {
+        enqueue: function(record) {
+            var records = this.observer.records_;
+            var length = records.length;
+            if (records.length > 0) {
+                var lastRecord = records[length - 1];
+                var recordToReplaceLast = selectRecord(lastRecord, record);
+                if (recordToReplaceLast) {
+                    records[length - 1] = recordToReplaceLast;
+                    return;
+                }
+            } else {
+                scheduleCallback(this.observer);
+            }
+            records[length] = record;
+        },
+        addListeners: function() {
+            this.addListeners_(this.target);
+        },
+        addListeners_: function(node) {
+            var options = this.options;
+            if (options.attributes) node.addEventListener("DOMAttrModified", this, true);
+            if (options.characterData) node.addEventListener("DOMCharacterDataModified", this, true);
+            if (options.childList) node.addEventListener("DOMNodeInserted", this, true);
+            if (options.childList || options.subtree) node.addEventListener("DOMNodeRemoved", this, true);
+        },
+        removeListeners: function() {
+            this.removeListeners_(this.target);
+        },
+        removeListeners_: function(node) {
+            var options = this.options;
+            if (options.attributes) node.removeEventListener("DOMAttrModified", this, true);
+            if (options.characterData) node.removeEventListener("DOMCharacterDataModified", this, true);
+            if (options.childList) node.removeEventListener("DOMNodeInserted", this, true);
+            if (options.childList || options.subtree) node.removeEventListener("DOMNodeRemoved", this, true);
+        },
+        addTransientObserver: function(node) {
+            if (node === this.target) return;
+            this.addListeners_(node);
+            this.transientObservedNodes.push(node);
+            var registrations = registrationsTable.get(node);
+            if (!registrations) registrationsTable.set(node, registrations = []);
+            registrations.push(this);
+        },
+        removeTransientObservers: function() {
+            var transientObservedNodes = this.transientObservedNodes;
+            this.transientObservedNodes = [];
+            transientObservedNodes.forEach(function(node) {
+                this.removeListeners_(node);
+                var registrations = registrationsTable.get(node);
+                for (var i = 0; i < registrations.length; i++) {
+                    if (registrations[i] === this) {
+                        registrations.splice(i, 1);
+                        break;
+                    }
+                }
+            }, this);
+        },
+        handleEvent: function(e) {
+            e.stopImmediatePropagation();
+            switch (e.type) {
+              case "DOMAttrModified":
+                var name = e.attrName;
+                var namespace = e.relatedNode.namespaceURI;
+                var target = e.target;
+                var record = new getRecord("attributes", target);
+                record.attributeName = name;
+                record.attributeNamespace = namespace;
+                var oldValue = e.attrChange === MutationEvent.ADDITION ? null : e.prevValue;
+                forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+                    if (!options.attributes) return;
+                    if (options.attributeFilter && options.attributeFilter.length && options.attributeFilter.indexOf(name) === -1 && options.attributeFilter.indexOf(namespace) === -1) {
+                        return;
+                    }
+                    if (options.attributeOldValue) return getRecordWithOldValue(oldValue);
+                    return record;
+                });
+                break;
+
+              case "DOMCharacterDataModified":
+                var target = e.target;
+                var record = getRecord("characterData", target);
+                var oldValue = e.prevValue;
+                forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+                    if (!options.characterData) return;
+                    if (options.characterDataOldValue) return getRecordWithOldValue(oldValue);
+                    return record;
+                });
+                break;
+
+              case "DOMNodeRemoved":
+                this.addTransientObserver(e.target);
+
+              case "DOMNodeInserted":
+                var target = e.relatedNode;
+                var changedNode = e.target;
+                var addedNodes, removedNodes;
+                if (e.type === "DOMNodeInserted") {
+                    addedNodes = [ changedNode ];
+                    removedNodes = [];
+                } else {
+                    addedNodes = [];
+                    removedNodes = [ changedNode ];
+                }
+                var previousSibling = changedNode.previousSibling;
+                var nextSibling = changedNode.nextSibling;
+                var record = getRecord("childList", target);
+                record.addedNodes = addedNodes;
+                record.removedNodes = removedNodes;
+                record.previousSibling = previousSibling;
+                record.nextSibling = nextSibling;
+                forEachAncestorAndObserverEnqueueRecord(target, function(options) {
+                    if (!options.childList) return;
+                    return record;
+                });
+            }
+            clearRecords();
+        }
+    };
+    global.JsMutationObserver = JsMutationObserver;
+    if (!global.MutationObserver) global.MutationObserver = JsMutationObserver;
+})(this);

--- a/dist/shadowStyles.js
+++ b/dist/shadowStyles.js
@@ -1,0 +1,350 @@
+// shadowStyles CSS Isolator
+// MIT License, ben@latenightsketches.com
+// src/shadowStyles.js
+
+// Main library
+(function(){
+  "use strict";
+  // A buffer must be made to bridge the elements to negated CSS selectors
+  var BUFFER_ATTR = 'css-negate';
+  var SHADOW_ATTR = 'shadow'
+  var UNIQUE_ID_LENGTH = 5;
+
+  // Cache node names to be shadowed while waiting for window.onload
+  var shadowNodes = [];
+  var documentReady = false;
+
+  // Main public method
+  // @param {string|element|array} nodeName - String: selector to match root
+  //                                          Element: element object as root
+  //                                          Array: combination of both
+  document.shadowStyles = function(nodeName){
+    shadowNodes.push(nodeName);
+    addShadowNodes();
+  };
+
+  // Helper public constant
+  document.shadowStyles.nativeSupport = (function(){
+    try{
+      document.querySelector('::shadow');
+    }catch(error){
+      return false;
+    };
+    return true;
+  })();
+
+  var addShadowNodes = function(){
+    if(documentReady){
+      while(shadowNodes.length){
+        var nodeName = shadowNodes.shift();
+        var shadowChildren = findChildren(nodeName);
+        negateShadowCssRules(shadowChildren);
+      };
+    };
+  };
+
+  window.addEventListener('load', function(){
+    documentReady = true;
+    if(!window.unwrap){
+      // Include dummy for when Polymer isn't loaded.
+      window.unwrap = function(obj){
+        return obj;
+      };
+    };
+    addShadowNodes();
+  }, true);
+
+  // Watch for changes to shadowed elements
+  var observer = new MutationObserver(function(mutations){
+    mutations.forEach(function(mutation){
+      var toUpdate = [];
+      if(mutation.type === 'attributes' &&
+          mutation.attributeName !== SHADOW_ATTR &&
+          mutation.attributeName !== BUFFER_ATTR){
+
+        // Update all children of this shadow
+        toUpdate = toUpdate.concat(findShadowPeers(mutation.target));
+      }else if(mutation.type === 'childList'){
+        Array.prototype.forEach.call(mutation.addedNodes, function(el){
+          if(el.nodeName !== '#text' && !el.getAttribute(BUFFER_ATTR)){
+            observer.observe(el, {attributes: true, childList: true});
+            el.setAttribute(BUFFER_ATTR, '');
+            toUpdate = toUpdate.concat(findShadowPeers(el));
+            el.addEventListener_ && el.addEventListener_('DOMNodeInserted',
+              function(event){
+                // Deal with MutationOberver timing before node inserted
+                negateShadowCssRules(toUpdate);
+              }, false);
+          };
+        });
+      };
+      negateShadowCssRules(arrayUnique(toUpdate));
+    });
+  });
+
+  // Watch for attribute changes to shadow ancestors
+  // Not Used with webcomponents.js shadow DOM polyfill
+  // Mutation event utilized below in findChildren() otherwise
+  var ancestorObserver = new MutationObserver(function(mutations){
+    mutations.forEach(function(mutation){
+      var toUpdate = Array.prototype.slice.call(
+        mutation.target.querySelectorAll('[shadow] *'), 0);
+      negateShadowCssRules(toUpdate);
+    });
+  });
+
+  var negateShadowCssRules = function(nodeList){
+    if(!nodeList.length) return;
+    Array.prototype.forEach.call(document.styleSheets, function(sheetRoot){
+      crawlRules(sheetRoot, function(rule, ruleIndex, sheet){
+        var selectors = rule.selectorText.split(',');
+        selectors.forEach(function(selector, selectorIndex){
+          selector = selector.trim();
+          // Match without pseudo classs in the selector
+          var selectorToMatch = selector.replace(regex.pseudoClass, '');
+          Array.prototype.forEach.call(nodeList, function(child){
+            var attrVal = child.getAttribute(BUFFER_ATTR) || '';
+            if(child.shadowRoot){
+              // Recurse into child Shadow DOM
+              negateShadowCssRules(child.shadowRoot.querySelectorAll('*'));
+            };
+            if(elMatchesEx(child, selectorToMatch)){
+              var shadowAttrPos = selector.lastIndexOf('[' + SHADOW_ATTR + ']');
+              var shadowRootEl = shadowAncestor(child);
+              if(shadowAttrPos > -1 && !shadowRootEl.shadowRoot){
+                // Selector has shadow attribute included
+                // and is not part of light DOM
+                if(shadowRootEl.host) shadowRootEl = shadowRootEl.host;
+                var nextSpacePos = selector.indexOf(' ', shadowAttrPos);
+                var shadowSelector = nextSpacePos > -1 ?
+                                      selector.substr(0, nextSpacePos) :
+                                      selector;
+                // Do not negate if closest shadowRoot host
+                if(elMatchesEx(shadowRootEl, shadowSelector)) return;
+              };
+              if(shadowAttrPos === -1 && 
+                  shadowRootEl && shadowRootEl.shadowRoot){
+                // Child is part of Light DOM
+                // Skip rules that don't have shadow attribute
+                return;
+              };
+              // Check if unique identifier already exists
+              var negateId = selector.match(regex.bufferAttr);
+              if(negateId){
+                negateId = negateId[2] || negateId[3];
+              }else{
+                negateId = randomString(UNIQUE_ID_LENGTH);
+                selector = insertBufferAttr(selector, negateId);
+                selectors[selectorIndex] = selector;
+                var ruleBody = rule.cssText.substr(rule.selectorText.length);
+                sheet.insertRule(selectors.join(', ') + ruleBody, ruleIndex + 1);
+                sheet.deleteRule(ruleIndex);
+                rule = sheet.cssRules[ruleIndex];
+              };
+
+              if(attrVal.indexOf(negateId) === -1){
+                attrVal += negateId;
+                child.setAttribute(BUFFER_ATTR, attrVal);
+              };
+            };
+          });
+        });
+      });
+    });
+  };
+
+  
+  var arrayUnique = function(a) {
+    return a.reduce(function(p, c) {
+      if (p.indexOf(c) < 0) p.push(c);
+      return p;
+    }, []);
+  };
+
+  var elMatches = (function(){
+    var options = [
+      'matches',
+      'msMatchesSelector',
+      'webkitMatchesSelector',
+      'mozMatchesSelector',
+      'oMatchesSelector'];
+    for(var i = 0; i < options.length; i++){
+      if(options[i] in document.documentElement){
+         return document.documentElement[options[i]];
+      };
+    };
+  })();
+
+  // @return true/false/undefined on invalid selector
+  var elMatchesEx = function(el, selector){
+    try{
+      var isMatch = elMatches.call(unwrap(el), selector);
+    }catch(err){
+      // Invalid selector
+      return;
+    };
+    return isMatch;
+  };
+
+  var crawlRules = function(sheet, ruleHandler){
+    if(sheet.cssRules){
+      Array.prototype.forEach.call(sheet.cssRules, function(rule, index){
+        if(rule.type === 1){
+          // Normal rule
+          ruleHandler(rule, index, sheet);
+        }else if(rule.cssRules) {
+          // Has child rules, like @media
+          crawlRules(rule, ruleHandler);
+        }else if(rule.styleSheet) {
+          // Has child sheet, like @import
+          crawlRules(rule.styleSheet, ruleHandler);
+        };
+      });
+    };
+  };
+
+  // Given an element in a shadow/light dom, find all peer elements
+  // @param {element} el
+  // @param {boolean} isRoot - el is shadowRoot or shadowRoot host
+  var findShadowPeers = function(el, isRoot){
+    var rootEl = isRoot ? el : shadowAncestor(el);
+    var peers = Array.prototype.slice.call(rootEl.querySelectorAll('*'), 0);
+    if(rootEl.host){
+      // Original element was in shadow DOM
+      // Also include light DOM peers
+      peers = peers.concat(Array.prototype.slice.call(
+                rootEl.host.querySelectorAll('*'), 0));
+    }else if(rootEl.shadowRoot){
+      // Original element was in light DOM
+      // Also include shadow DOM peers
+      peers = peers.concat(Array.prototype.slice.call(
+                rootEl.shadowRoot.querySelectorAll('*'), 0));
+    };
+    return peers;
+  };
+
+  // Return nearest ShadowRoot or [shadow] element
+  var shadowAncestor = function(el){
+    while(el.parentNode){
+      if(window.ShadowRoot && el.parentNode instanceof ShadowRoot){
+        return el.parentNode;
+      }else if(el.hasAttribute(SHADOW_ATTR)){
+        return el;
+      };
+      el = el.parentNode;
+    };
+  };
+
+  // Return array of ShadowRoot Host or [shadow] element
+  // Called for selector matching so ShadowRoots are not helpful
+  var findShadowAncestors = function(el){
+    var output = [];
+    while (el){
+      el = shadowAncestor(el);
+      if(el){
+        if(el.host) el = el.host; // Break out of ShadowRoot
+        output.push(el);
+      };
+    };
+    return output;
+  };
+
+  // Return all ancestor elements
+  var findAncestors = function(el){
+    var ancestors = [];
+    while(el.parentNode){
+      ancestors.push(el.parentNode);
+      el = el.parentNode;
+    };
+    return ancestors;
+  };
+
+  // Find children of roots, register with observer
+  // @param {string|element|array} selector
+  // @return {array} Child elements
+  var findChildren = function(selector){
+    var roots = [];
+    var children = [];
+    if(typeof selector === 'string'){
+      roots = document.querySelectorAll(selector);
+    }else if(selector instanceof Array){
+      selector.forEach(function(cur){
+        children = children.concat(findChildren(cur));
+      });
+    }else{
+      // Selector is element
+      roots = [selector];
+    };
+    Array.prototype.forEach.call(roots, function(rootEl){
+      var shadowRoot = rootEl.shadowRoot || rootEl;
+      observer.observe(shadowRoot, {attributes: true, childList: true});
+      rootEl.setAttribute(SHADOW_ATTR, '');
+
+      findAncestors(rootEl).forEach(function(ancestor){
+        if(ancestor.addEventListener_){
+          // Polymer Shadow DOM blocks mutation events but provides _ suffix
+          // to access original method. For unknown reason, MutationObserver
+          // does not work with these ancestors with Polymer
+          ancestor.addEventListener_('DOMAttrModified', function(event){
+            if(event.target !== unwrap(ancestor) ||
+                event.attrName === BUFFER_ATTR ||
+                event.attrName === SHADOW_ATTR) return;
+            var toUpdate = findShadowPeers(shadowRoot, true);
+            negateShadowCssRules(toUpdate);
+          }, true);
+        }else{
+          // Using without Shadow DOM polyfill
+          ancestorObserver.observe(ancestor, {attributes: true});
+        };
+      });
+
+      var found = findShadowPeers(shadowRoot, true);
+      Array.prototype.forEach.call(found, function(child){
+        observer.observe(child, {attributes: true, childList: true});
+        child.setAttribute(BUFFER_ATTR, '');
+        children.push(child);
+      });
+    });
+    return children;
+  };
+
+  // Add buffer attribute to selector
+  // Takes existing pseudo class position into consideration
+  // @param {string} selector
+  // @param {string} selectorId - unique identifier
+  // @return {string} - Modified selector
+  var insertBufferAttr = function(selector, selectorId){
+    var colonPos = selector.lastIndexOf(':');
+    var lastSpace = selector.lastIndexOf(' ');
+    var bufferAttr = ':not([' + BUFFER_ATTR + '*="' + selectorId + '"])';
+    if(colonPos === -1){
+      // No pseudo-class, place at end
+      return selector + bufferAttr;
+    }else{
+      // Place before other pseudo-classes
+      var anotherColon = selector.lastIndexOf(':', colonPos - 1);
+      while(anotherColon > lastSpace){
+        colonPos = anotherColon;
+        anotherColon = selector.lastIndexOf(':', anotherColon - 1);
+      };
+      return selector.substr(0, colonPos) +
+              bufferAttr +
+              selector.substr(colonPos);
+    };
+  };
+
+  var randomString = function(length){
+    var text = "",
+        possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789";
+    for(var i=0; i < length; i++){
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+    };
+    return text;
+  };
+
+  var regex = {
+    bufferAttr: new RegExp(':not\\(\\[' + BUFFER_ATTR + '\\*=("([^"]+)"|\'([^\']+)\')\\]\\)'),
+    pseudoClass: new RegExp('(:after|:before|::after|::before|:hover|' +
+        ':active|:focus|:checked|:valid|:invalid)', 'gi')
+  };
+})();

--- a/lib/client-report.html
+++ b/lib/client-report.html
@@ -4,51 +4,53 @@
 
 <template name="velocity">
   {{#if notInMirror}}
-  <div id="velocityOverlay" class="{{#if overlayIsVisible}}visible{{/if}} {{statusWidgetClass}}">
-    <button class="velocity-btn-close display-toggle" data-target="velocityOverlay"></button>
+    <div id="velocity">
+      <div id="velocityOverlay" class="{{#if overlayIsVisible}}visible{{/if}} {{statusWidgetClass}}">
+        <button class="velocity-btn-close display-toggle" data-target="velocityOverlay"></button>
 
-    <div class="velocity-logo">Velocity</div>
+        <div class="velocity-logo">Velocity</div>
 
-    {{#if resetting}}
-      {{> velocityResetNotification}}
-    {{/if}}
+        {{#if resetting}}
+          {{> velocityResetNotification}}
+        {{/if}}
 
-    {{> velocitySummary}}
+        {{> velocitySummary}}
 
-    {{> velocityControlPanel}}
+        {{> velocityControlPanel}}
 
-    {{#each frameworks}}
-      {{> velocityReports}}
-    {{/each}}
+        {{#each frameworks}}
+          {{> velocityReports}}
+        {{/each}}
 
-    {{#if active 'showLogs'}}
-    <div class="velocity-section-header">
-      <span class="velocity-section-name">Logs</span>
-    </div>
-      {{> velocityLogs}}
-    {{/if}}
+        {{#if active 'showLogs'}}
+        <div class="velocity-section-header">
+          <span class="velocity-section-name">Logs</span>
+        </div>
+          {{> velocityLogs}}
+        {{/if}}
 
-    {{#if active 'showFiles'}}
-    <div class="velocity-section-header">
-      <span class="velocity-section-name">Test files</span>
-    </div>
-      {{> velocityTestFiles}}
-    {{/if}}
+        {{#if active 'showFiles'}}
+        <div class="velocity-section-header">
+          <span class="velocity-section-name">Test files</span>
+        </div>
+          {{> velocityTestFiles}}
+        {{/if}}
 
-    {{#if mochaPresent}}
-    <div class="velocity-iframe {{#if active 'showMochaIframe'}}visible{{/if}}">
-      <div class="velocity-section-header">
-        <span class="velocity-section-name">Mocha iframe</span>
+        {{#if mochaPresent}}
+        <div class="velocity-iframe {{#if active 'showMochaIframe'}}visible{{/if}}">
+          <div class="velocity-section-header">
+            <span class="velocity-section-name">Mocha iframe</span>
+          </div>
+          {{> mochaweb}}
+        </div>
+        {{/if}}
       </div>
-      {{> mochaweb}}
-    </div>
-    {{/if}}
-  </div>
 
-  <div id="velocity-status-widget" class="{{statusWidgetClass}} display-toggle"
-       data-target="velocityOverlay" title="Show test results">
-    <i class="velocity-icon-status"></i>
-  </div>
+      <div id="velocity-status-widget" class="{{statusWidgetClass}} display-toggle"
+           data-target="velocityOverlay" title="Show test results">
+        <i class="velocity-icon-status"></i>
+      </div>
+    </div>
   {{/if}}
 </template>
 

--- a/lib/client-report.js
+++ b/lib/client-report.js
@@ -45,6 +45,15 @@ Template.velocity.created = function () {
   })
 };
 
+Template.velocity.rendered = function () {
+  var container = this.find('#velocity');
+  if(!container){
+    setTimeout(Template.velocity.rendered.bind(this), 10);
+  }else if(document.shadowStyles){
+    document.shadowStyles(container);
+  }
+};
+
 Template.velocity.helpers({
   statusWidgetClass: function () {
     var aggregateResult = VelocityAggregateReports.findOne({name: 'aggregateResult'});

--- a/lib/client-report.less
+++ b/lib/client-report.less
@@ -1,4 +1,4 @@
-#velocityOverlay {
+#velocity[shadow] #velocityOverlay {
   @import "velocity.less";
 
   z-index: 9000;

--- a/lib/status-widget.less
+++ b/lib/status-widget.less
@@ -1,4 +1,4 @@
-#velocity-status-widget {
+#velocity[shadow] #velocity-status-widget {
   @import "velocity.less";
 
   z-index: 8000;

--- a/package.js
+++ b/package.js
@@ -12,6 +12,9 @@ Package.onUse(function(api) {
 
   api.use(['underscore', 'templating','amplify@1.0.0', 'less'], 'client');
 
+  api.addFiles('dist/mutationObserver.polyfill.js', 'client');
+  api.addFiles('dist/shadowStyles.js', 'client');
+
   api.addFiles('lib/reamplify.js', 'client');
 
   api.addFiles('lib/velocity.js', 'client');


### PR DESCRIPTION
Instead of using WebComponents to isolate CSS styles (since Polymer does not provide a polyfill for isolated CSS in Shadow DOM), I have implemented my [`shadowStyles` library](https://github.com/numtel/shadowstyles). This library negates any styles from the site that would be applied to the shadowed elements by carefully applying `:not()` selectors to loaded stylesheets and attributes to affected elements.

I have manually tested this patch to be working in Chrome and Firefox on Ubuntu as well as IE9/10 on Win7. Verification over multiple apps and configurations would be very smart before release.

Please let me know of any issues that come up.