### PR TITLE
Status widget background color transparency fix

### DIFF
--- a/lib/client-report.less
+++ b/lib/client-report.less
@@ -459,4 +459,5 @@
 
 #velocity-status-widget {
   transition: right 0.25s ease-in-out;
+  background-color: rgba(255, 255, 255, 0);
 }


### PR DESCRIPTION
To remove the white square around the velocity status widget over my non-white app background I simply made the velocity status widget background transparent.