### PR TITLE
Fixed reporting of total time so that the "ms" suffix is always shown…

### DIFF
--- a/lib/client-report.js
+++ b/lib/client-report.js
@@ -198,7 +198,7 @@ Template.velocitySummary.helpers({
 
     if (ms >= 1000) return Math.round(ms / 1000) + ' s';
 
-    return ms ? ms : 0 + ' ms';
+    return (ms ? ms : 0) + ' ms';
   },
   regularPlural: function (count, word, suffix) {
     if (count === 1) return word;


### PR DESCRIPTION
… when the total time is less than 1 second (previously the ms suffix was only shown for 0 ms).

The total time now reads "1 test passed in 47 ms" instead of "1 test passed in 47".