### PR TITLE
Fix undefined mirror errors

### DIFF
--- a/lib/client-report.js
+++ b/lib/client-report.js
@@ -113,10 +113,14 @@ Template.velocityReports.helpers({
     return frameworkStatus(this.name)
   },
   mirrorStatus: function () {
-    return VelocityMirrors.findOne({framework: this.name}).state.trim();
+    var mirror = VelocityMirrors.findOne({framework: this.name});
+
+    return mirror && mirror.state.trim();
   },
   mirrorUrl: function () {
-    return VelocityMirrors.findOne({framework: this.name}).rootUrl;
+    var mirror = VelocityMirrors.findOne({framework: this.name});
+
+    return mirror && mirror.rootUrl;
   },
   isPassed: function (status) {
     return status === 'passed'


### PR DESCRIPTION
After the release 0.7.2 I got a lot of "Exception in template helper: TypeError: Cannot read property 'rootUrl' of undefined" messages.

This happened after the fix of #77, in the helper we got two findOnes with an immediate call to a property, and the finds returns null until the mirror is up, so the console gets lots of errors because of this.

Cheers.